### PR TITLE
Setsockopt don't take effect

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 
 #define DIV_RATIO 1000
 
+#include <winsock2.h>
 #include <windows.h>
 #include <comutil.h>
 #include <stdio.h>
@@ -15,6 +16,7 @@
 
 #define WS_VER_MAJOR 2
 #define WS_VER_MINOR 2
+#include <ws2tcpip.h>
 #pragma comment(lib, "ws2_32.lib")
 
 #include "../DeckLinkAPI_h.h"


### PR DESCRIPTION
If I link the project with Ws2_32.lib, setsockopt() with IP_MULTICAST_TTL will succeed for example . 
However, the multicast TTL setting won't take effect.
The TTL value still remains as the default(1).

Options that fall into this category include:

- IP_MULTICAST_IF
- IP_MULTICAST_TTL
- IP_MULTICAST_LOOP

[https://docs.microsoft.com/en-us/troubleshoot/windows/win32/header-library-requirement-socket-ipproto-ip](url)